### PR TITLE
Cleanup crypto code

### DIFF
--- a/src/commands/get_multi.rs
+++ b/src/commands/get_multi.rs
@@ -50,7 +50,7 @@ pub fn get_multi(input: &str, keymap: &KeyMap) -> Result<()> {
     for secret_key in input.secrets.unwrap_or_default() {
         match keymap.decrypt(&secret_key.secret) {
             Ok(uncrypted_vault) => {
-                match String::from_utf8(uncrypted_vault.get_content().clone()) {
+                match String::from_utf8(uncrypted_vault.get_content().to_vec()) {
                     Ok(uncrypted_vault_uft8) => {
                         secrets.insert(
                             secret_key.secret.to_string(),
@@ -62,7 +62,7 @@ pub fn get_multi(input: &str, keymap: &KeyMap) -> Result<()> {
                     }
                     Err(error) => {
                         errors.push(format!(
-                            "could decode key {}. may it's not valid utf8?, error: {}",
+                            "could decode key {}. maybe it's not valid utf8?, error: {}",
                             &secret_key.secret, error
                         ));
                     }

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -1,11 +1,14 @@
 use crate::Result;
-use crate::key::Pem;
 use crate::key::PublicKey;
+use crate::key::{Pem, PrivateKey};
 use crate::proto::VaultFile;
-use anyhow::{Context, anyhow, bail};
-use openssl::rand::rand_bytes;
+use anyhow::{Context, ensure};
+use openssl::rand::{rand_bytes, rand_priv_bytes};
 use openssl::rsa::{Padding, Rsa};
 use openssl::symm::{Cipher, decrypt, encrypt};
+
+const KEY_SIZE: usize = 256 / 8;
+const IV_SIZE: usize = 128 / 8;
 
 #[derive(Clone)]
 pub struct CryptedFileContent {
@@ -14,12 +17,12 @@ pub struct CryptedFileContent {
 }
 
 impl CryptedFileContent {
-    pub fn get_crypted_password(&self) -> &Vec<u8> {
-        &self.crypted_password
+    pub fn get_crypted_password(&self) -> &[u8] {
+        self.crypted_password.as_slice()
     }
 
-    pub fn get_content(&self) -> &Vec<u8> {
-        &self.content
+    pub fn get_content(&self) -> &[u8] {
+        self.content.as_slice()
     }
 }
 
@@ -33,8 +36,8 @@ impl UncryptedVaultFile {
         UncryptedVaultFile { content }
     }
 
-    pub fn get_content(&self) -> &Vec<u8> {
-        &self.content
+    pub fn get_content(&self) -> &[u8] {
+        self.content.as_slice()
     }
 }
 
@@ -45,12 +48,12 @@ impl Crypto {
         public_key: &PublicKey,
         uncrypted_vault_file: &UncryptedVaultFile,
     ) -> Result<CryptedFileContent> {
-        // at first we need a password, we store the password in the "key"
-        let mut password = [0; 256 / 8];
-        rand_bytes(&mut password)
+        // at first, we need a password, we store the password in the "key"
+        let mut password = [0; KEY_SIZE];
+        rand_priv_bytes(&mut password)
             .context("could not create random bytes to encrypt vault_file.")?;
 
-        let mut iv = vec![0; 128 / 8];
+        let mut iv = vec![0; IV_SIZE];
         rand_bytes(&mut iv).context("could not create random bytes for iv.")?;
 
         let key = Crypto::key_encrypt(public_key, &password)
@@ -77,51 +80,105 @@ impl Crypto {
     }
 
     pub fn decrypt(pem: &Pem, crypted_vault_file: &VaultFile) -> Result<UncryptedVaultFile> {
-        // at first we need to extract the password using the private key.
-        let password: Vec<u8> = Self::key_decrypt(pem, crypted_vault_file.get_keyfile_content())
-            .context("could not decrypt password using private key")?;
+        // at first, we need to extract the password using the private key.
+        let password = Self::key_decrypt(
+            pem.get_private_key(),
+            crypted_vault_file.get_keyfile_content(),
+        )
+        .context("could not decrypt password using private key")?;
 
         let cipher = Cipher::aes_256_cbc();
 
-        if crypted_vault_file.get_secret_content().len() < 128 / 8 {
-            bail!("crypted size is to small, couldnt read enought for IV");
-        }
+        ensure!(
+            crypted_vault_file.get_secret_content().len() >= IV_SIZE,
+            "crypted size is to small, couldnt read enought for IV"
+        );
 
-        let iv = &crypted_vault_file.get_secret_content()[0..128 / 8];
+        let (iv, content) = crypted_vault_file.get_secret_content().split_at(IV_SIZE);
 
-        let content = &crypted_vault_file.get_secret_content()[128 / 8..];
-
-        let content = decrypt(cipher, &password, Some(iv), content)
+        let content = decrypt(cipher, password.as_slice(), Some(iv), content)
             .context("could not encrypt using content")?;
 
         Ok(UncryptedVaultFile { content })
     }
 
-    pub fn key_encrypt(public_key: &PublicKey, data: &[u8]) -> Result<Vec<u8>> {
+    pub fn key_encrypt(public_key: &PublicKey, key: &[u8; KEY_SIZE]) -> Result<Vec<u8>> {
         let rsa = openssl::rsa::Rsa::public_key_from_pem(public_key.get_data())
             .with_context(|| format!("invalid public key {}", &public_key.get_name()))?;
 
-        //let rsa = Rsa::public_key_from_pem(&self.public_key).map_err(|_| { "invalid public key".to_string() })?;
+        // Since this is a low level function, we can only encrypt data that is less than the
+        // size of a signature minus the identifier marker of the padding (11 for PKCS1).
+        assert!(KEY_SIZE < (rsa.size() as usize - 11));
+
         let mut encrypted_data: Vec<u8> = vec![0; rsa.size() as usize];
 
-        // look at http://php.net/manual/de/function.openssl-public-encrypt.php
-        let _ = rsa
-            .public_encrypt(data, encrypted_data.as_mut_slice(), Padding::PKCS1)
+        let size = rsa
+            .public_encrypt(key, encrypted_data.as_mut_slice(), Padding::PKCS1)
             .context("could not encrypt")?;
+
+        // The size of the created signature is pre-determined. Data that is written into it
+        // will always be padded to the full signature size.
+        assert_eq!(size, encrypted_data.len());
 
         Ok(encrypted_data)
     }
 
-    pub fn key_decrypt(pem: &Pem, data: &[u8]) -> Result<Vec<u8>> {
-        let rsa = Rsa::private_key_from_pem(pem.get_private_key().get_data())
-            .context("invalid private key")?;
+    pub fn key_decrypt(private_key: &PrivateKey, encrypted_key: &[u8]) -> Result<[u8; KEY_SIZE]> {
+        let rsa = Rsa::private_key_from_pem(private_key.get_data())
+            .with_context(|| format!("invalid private key {}", &private_key.get_name()))?;
 
-        let mut decrypted_data: Vec<u8> = vec![0; rsa.size() as usize];
+        // The maximal encrypted data can only be the size of the signature minus the identifier
+        // marker of the padding (11 for PKCS1). The OpenSSL Rust crate currently doesn't properly
+        // check the size based on the padding and always checks as if no padding is used.
+        let mut decrypted_data = vec![0; rsa.size() as usize];
 
         let size = rsa
-            .private_decrypt(data, decrypted_data.as_mut_slice(), Padding::PKCS1)
+            .private_decrypt(encrypted_key, decrypted_data.as_mut_slice(), Padding::PKCS1)
             .context("could not decrypt")?;
 
-        Ok(decrypted_data[..size].to_vec())
+        assert!(size >= KEY_SIZE);
+
+        let mut key = [0; KEY_SIZE];
+
+        key.copy_from_slice(&decrypted_data[..KEY_SIZE]);
+
+        Ok(key)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::key::{Pem, PrivateKey, PublicKey};
+
+    fn generate_pem() -> Pem {
+        let rsa = openssl::rsa::Rsa::generate(1024).unwrap();
+
+        let private_key = PrivateKey {
+            data: rsa.private_key_to_pem().unwrap(),
+            name: "private key".to_string(),
+        };
+
+        let public_key = PublicKey {
+            data: rsa.public_key_to_pem().unwrap(),
+            name: "public key".to_string(),
+        };
+
+        Pem::new(private_key, public_key)
+    }
+
+    #[test]
+    fn test_key_round_trip() {
+        let pem = generate_pem();
+        let private_key = pem.get_private_key();
+        let public_key = pem.get_public_key();
+
+        let mut aes_key = [0; KEY_SIZE];
+        rand_priv_bytes(&mut aes_key).unwrap();
+
+        let encrypted_data = Crypto::key_encrypt(public_key, &aes_key).unwrap();
+        let decrypted_data = Crypto::key_decrypt(private_key, &encrypted_data).unwrap();
+
+        assert_eq!(aes_key.as_slice(), decrypted_data.as_slice());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,10 @@ fn run() -> Result<()> {
         FilesystemCheckResult::IsOk => {}
         FilesystemCheckResult::IsNotInstalled => enter_filesystem_wizard()?,
         FilesystemCheckResult::HasErrors(ref errors) => {
-            bail!("issues with the filesystem, e.g. a basic directory could be missing\n{}", errors.join("\n"));
+            bail!(
+                "issues with the filesystem, e.g. a basic directory could be missing\n{}",
+                errors.join("\n")
+            );
         }
     };
 

--- a/src/template/mod.rs
+++ b/src/template/mod.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use crate::key::key_map::KeyMap;
-use anyhow::{Context, anyhow};
+use anyhow::Context;
 use regex::Regex;
 use std::fs::File;
 use std::io::Read;


### PR DESCRIPTION
A lot of cleanup of the crypto related code. We use some standard library functionality that was implemented manually before.

We also follow to OpenSSL guideline now to use different RAND functions for public (IV) and private (KEY) data.